### PR TITLE
Prevent compilation error on android platform

### DIFF
--- a/YandexMetricaPluginSample/Assets/AppMetrica/Editor/PostprocessBuildPlayerAppMetrica.cs
+++ b/YandexMetricaPluginSample/Assets/AppMetrica/Editor/PostprocessBuildPlayerAppMetrica.cs
@@ -9,7 +9,9 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 using System.IO;
 using System.Collections;
 
@@ -48,6 +50,7 @@ public class PostprocessBuildPlayerAppMetrica
     [PostProcessBuild]
     public static void OnPostprocessBuild (BuildTarget buildTarget, string path)
     {
+#if UNITY_IOS
 #if UNITY_5 || UNITY_2017_1_OR_NEWER
         var expectedTarget = BuildTarget.iOS;
 #else
@@ -80,5 +83,6 @@ public class PostprocessBuildPlayerAppMetrica
 
             File.WriteAllText (projectPath, project.WriteToString ());
         }
+#endif
     }
 }


### PR DESCRIPTION
If you have one unity project for iOS and Android platform, you can't compile it without hand editing .cs (put platform dependent compilation macros to separate implementation)